### PR TITLE
Add external link check, with redirect

### DIFF
--- a/iogt/processors.py
+++ b/iogt/processors.py
@@ -6,3 +6,9 @@ def compress_settings(request):
         'STATIC_URL': settings.STATIC_URL,
         'ENV': settings.ENV
     }
+
+
+def external_link(request):
+    return {
+        'external_link_check': settings.EXTERNAL_LINK_CHECK,
+    }

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -40,6 +40,7 @@ ALLOWED_HOSTS = environ.get('ALLOWED_HOSTS', '*').split(",")
 # backend - e.g. in notification emails. Don't include '/admin' or
 # a trailing slash
 BASE_URL = 'http://example.com'
+EXTERNAL_LINK_CHECK = "internetofgoodthings.org"
 
 
 # Application definition
@@ -138,6 +139,7 @@ TEMPLATES = [
                 'wagtail.contrib.settings.context_processors.settings',
                 'molo.core.context_processors.locale',
                 'iogt.processors.compress_settings',
+                'iogt.processors.external_link',
             ],
         },
     },

--- a/iogt/settings/dev.py
+++ b/iogt/settings/dev.py
@@ -10,6 +10,8 @@ BROKER_URL = 'amqp://rabbit:secret@rabbitmq.com:5672/molo-iogt'
 
 ALLOWED_HOSTS = environ.get('ALLOWED_HOSTS', '127.0.0.1').split(",")
 
+EXTERNAL_LINK_CHECK = "127.0.0.1"
+
 try:
     from .local import *  # noqa
 except ImportError:

--- a/iogt/templates/base.html
+++ b/iogt/templates/base.html
@@ -268,7 +268,6 @@
             </li>
           {% endif %}
           {% footer_page %}
-          
         </ul>
       </div>
 
@@ -276,6 +275,18 @@
         <p>&copy; The Internet of Good Things</p>
       </div>
       {% endblock %}
+      {% block external-link %}
+      <script>
+        // convert all external links to redirect to banner
+        var links = document.getElementsByTagName("a");
+        for (i = 0; i < links.length; i++) {
+            var link = links[i].href;
+            if (link.indexOf("{{ external_link_check }}") === -1 && link.indexOf("{% url 'external_link' %}") === -1) {
+                links[i].href = "{% url 'external_link' %}?next=" + link;
+            }
+        }
+      </script>
+      {% endblock external-link %}
       {% block extra_js %}{% endblock %}
       {% wagtailuserbar %}
     </body>

--- a/iogt/templates/core/external-link.html
+++ b/iogt/templates/core/external-link.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+  <div class="article-list">
+    <p>{% trans "You are about to leave The Internet of Good Things, and may be charged by your service provider" %}</p>
+    <a href="{{ next }}">{% trans "Click to continue" %}</a>
+  </div>
+{% endblock content %}
+
+{% block external-link %}{% endblock external-link %}

--- a/iogt/urls.py
+++ b/iogt/urls.py
@@ -14,7 +14,7 @@ from wagtail.wagtailcore import urls as wagtail_urls
 from molo.profiles.views import RegistrationDone
 from molo.profiles.forms import DoneForm
 
-from iogt.views import health_iogt
+from iogt.views import ExternalLink, health_iogt
 
 
 urlpatterns = []
@@ -28,6 +28,7 @@ if settings.ENABLE_SSO:
 
 
 urlpatterns += [
+    url(r'^external-link/', ExternalLink.as_view(), name="external_link"),
     url(r'^django-admin/', include(admin.site.urls)),
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),

--- a/iogt/views.py
+++ b/iogt/views.py
@@ -5,6 +5,7 @@ from os import environ
 from pyrabbit.api import Client
 from django.conf import settings
 from django.http import JsonResponse
+from django.views.generic import TemplateView
 from rest_framework import status
 
 
@@ -33,3 +34,12 @@ def health_iogt(request):
     app_id = environ.get('MARATHON_APP_ID', None)
     ver = environ.get('MARATHON_APP_VERSION', None)
     return JsonResponse({'id': app_id, 'version': ver}, status=status_code)
+
+
+class ExternalLink(TemplateView):
+    template_name = "core/external-link.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data()
+        context["next"] = self.request.GET.get("next")
+        return context


### PR DESCRIPTION
setting `EXTERNAL_LINK_CHECK` determines valid site, any link not including this value will result in a redirect to the external link page, which warns user that they are leaving the site.

Verbiage may need to be cleaned up on redirect page.