### PR TITLE
Fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install coveralls
 script:
   - flake8
-  - py.test
+  - py.test --disable-warnings
 after_success:
   - coveralls
 

--- a/iogt/admin.py
+++ b/iogt/admin.py
@@ -3,5 +3,5 @@ from wagtail.wagtailcore import hooks
 
 @hooks.register('construct_main_menu')
 def show_reactionquestions(request, menu_items):
-        menu_items[:] = [
-            item for item in menu_items if item.name != 'reactionquestions']
+    menu_items[:] = [
+        item for item in menu_items if item.name != 'reactionquestions']

--- a/iogt/middleware.py
+++ b/iogt/middleware.py
@@ -92,8 +92,8 @@ class IogtMoloGoogleAnalyticsMiddleware(MoloGoogleAnalyticsMiddleware):
 
         def calculate_age(dob):
             today = get_today()
-            return (today.year - dob.year -
-                    ((today.month, today.day) < (dob.month, dob.day)))
+            return (today.year - dob.year - (
+                (today.month, today.day) < (dob.month, dob.day)))
 
         # send user unique id and details after cookie's been set
         if hasattr(request, 'user') and hasattr(request.user, 'profile'):

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -472,10 +472,10 @@ EXTRA_LANG_INFO = {
         'name_local': 'دری,'
     },
     'ch': {
-          'bidi': False,
-          'code': 'ch',
-          'name': 'Chichewa',
-          'name_local': 'Chichewa'
+        'bidi': False,
+        'code': 'ch',
+        'name': 'Chichewa',
+        'name_local': 'Chichewa'
     },
     'sho': {
         'bidi': False,

--- a/iogt/tests/test_middleware.py
+++ b/iogt/tests/test_middleware.py
@@ -2,6 +2,8 @@ import mock
 import datetime
 import responses
 
+import pytest
+
 from django.test import TestCase, Client, RequestFactory, override_settings
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -224,6 +226,7 @@ class TestFaceBookPixelHistoryCounter(TestCase, MoloTestCaseMixin):
         self.english_section = self.mk_section(
             self.section_index, title='English section')
 
+    @pytest.mark.skip(reason="Set up Facebook pixel tracking (or remove)")
     def test_more_that_3_page_views(self):
         """ test if the no script html tag exists """
         view_count = 5
@@ -238,6 +241,7 @@ class TestFaceBookPixelHistoryCounter(TestCase, MoloTestCaseMixin):
             view_count + 1
         )
 
+    @pytest.mark.skip(reason="Set up Facebook pixel tracking (or remove)")
     def test_less_that_3_page_views(self):
         """ test if the no script html tag exists """
         response = self.client.get(reverse('search'))

--- a/iogt/tests/test_middleware.py
+++ b/iogt/tests/test_middleware.py
@@ -4,7 +4,6 @@ import responses
 
 import pytest
 
-from django.test import TestCase, Client, RequestFactory, override_settings
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ celery<4.0
 gunicorn
 psycopg2
 django_compressor==2.2
+django-appconf==1.0.3
 django-mptt==0.8.7
 django-google-analytics-app==4.3.3
 Unidecode==0.04.16


### PR DESCRIPTION
1. Both the Python 2 and Python 3 tests were failing on the Facebook Pixel tests.

    @saxix [removed Facebook tracking](https://github.com/unicef/molo-iogt/commit/2ee96711) on 22 March 2019 but did not disable the two corresponding tests. This appears to have happened before Travis was set up on the unicef fork of the repository, so the failing tests went unnoticed. I've now disabled these two tests, but they can be reinstated if Facebook tracking is enabled again in the future.

2. The Python 2 code fails if the version of `django-appconf` installed is greater than version 1.0.3

    `django-appconf` broke the Python 2 codebase on 21 January 2020 with the release of version 1.0.4. The `django-appconf` team didn't follow [semantic versioning](https://semver.org/) and removed Python 2 compabilty on a patch release ([here](https://github.com/django-compressor/django-appconf/pull/57/files#diff-02fd9b954a3f46059865e5e8758d5670L109)). This affected us because `django_compressor` has `django-appconf` as a dependency. `django_compressor` doesn't pin it's dependencies with future breaking changes in mind (i.e. they used `"django-appconf >= 1.0.3"`) which allowed the `django-appconf` version to drift to the latest release. When we remove Python 2 support we'll allow `django_compressor` to choose the `django-appconf` version again.