### PR TITLE
Pin `django-import-export` to final version that supports Django < 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ gunicorn
 psycopg2
 django_compressor==2.2
 django-appconf==1.0.3
+django-import-export<2.4.0
 django-mptt==0.8.7
 django-google-analytics-app==4.3.3
 Unidecode==0.04.16


### PR DESCRIPTION
`django-import-export` broke support for Django<2.0.0 with the release of their version 2.4.0 [on 5th October 2020](https://pypi.org/project/django-import-export/#history).

This broke the IoGT build because `molo.core` does not pin this dependency to any version in [requirements.txt](https://github.com/praekeltfoundation/molo/blob/b814e7427d290a7c459bc305b8a34871236e1097/setup.py#L30).